### PR TITLE
Add backslash to NuSpecFile search path when SolutionDir isn't defined

### DIFF
--- a/NuSpec.ReferenceGenerator.nuspec
+++ b/NuSpec.ReferenceGenerator.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>NuSpec.ReferenceGenerator</id>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <title>NuSpec Dependency Generator</title>
     <authors>Oren Novotny</authors>
     <licenseUrl>https://raw.githubusercontent.com/onovotny/ReferenceGenerator/master/LICENSE.txt</licenseUrl>

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ This tool is a command line that you can call in other ways. The parameters are 
 - This tool does not currently run on mono if you're using an "classic PCL". The tool needs all of the PCL contracts from the `Reference Assemblies` folder for comparison; if there's an equiv on Mono, then this could be fixed. Alternatively, if you only need project.json based projects, then there's no limitation.
 
 ## Changelog
+- 1.3.3: Add backslash to NuSpecFile search path when SolutionDir isn't defined, don't define SolutionDir if it's not already defined
 - 1.3.2: Check for blank `$(SolutionDir)` and default to parent directory of project
 - 1.3.1: Set default TFM for UWP class libraries to `uap10.0`
 - 1.3: Fix bug when using with UWP class libraries. Also include support for *projectName*.project.json added in NuGet 3.2.

--- a/src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets
+++ b/src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets
@@ -16,12 +16,13 @@
   </ItemGroup>
   
   <PropertyGroup>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)..\</SolutionDir>
+    <NuSpecSearchRoot>$(SolutionDir)</NuSpecSearchRoot>
+    <NuSpecSearchRoot Condition="$(NuSpecSearchRoot) == '' Or $(NuSpecSearchRoot) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</NuSpecSearchRoot>
   </PropertyGroup>
   
   <ItemGroup Condition="@(NuSpecFile) == ''">
     <!-- Look for a nuspec that matches the output name -->
-    <NuSpecFile Include="$(SolutionDir)**\$(TargetName).nuspec">
+    <NuSpecFile Include="$(NuSpecSearchRoot)**\$(TargetName).nuspec">
       <Visible>False</Visible>
     </NuSpecFile>
   </ItemGroup>


### PR DESCRIPTION
Also don't define SolutionDir if it's not already defined.
