### PR TITLE
Add developmentDependency=true to nuspec

### DIFF
--- a/NuSpec.ReferenceGenerator.nuspec
+++ b/NuSpec.ReferenceGenerator.nuspec
@@ -10,5 +10,6 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>nuspec coreclr dnx nuget dependency dotnet</tags>
     <description>Tool to auto-generate BCL package nuspec dependencies for CoreCLR projects</description>
+    <developmentDependency>true</developmentDependency>
   </metadata>
 </package>


### PR DESCRIPTION
This prevents this package from itself showing up as a transitive dependency since it is only used by the local build of the consuming project.

Fix #10
