### PR TITLE
Fixed typo

### DIFF
--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -10,7 +10,7 @@ Function Install-NuGet(
         return
     }
 
-    Write-Host "Installating NuGet.exe..."
+    Write-Host "Installing NuGet.exe..."
     Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile $nuGet
     Write-Host "Successfully installed NuGet."
 }


### PR DESCRIPTION
Fixes a small typo in the output of the `Build.ps1` command.
