### PR TITLE
First attempt at Mono build [NOT READY FOR MERGING]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+# NuGet directory
+.nuget

--- a/ReferenceGenerator.Mono.sln
+++ b/ReferenceGenerator.Mono.sln
@@ -1,0 +1,54 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceGenerator", "src\ReferenceGenerator\ReferenceGenerator.csproj", "{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}"
+	ProjectSection(ProjectDependencies) = postProject
+		{DA03B415-AE61-4218-82B9-F5CFF0B7AF88} = {DA03B415-AE61-4218-82B9-F5CFF0B7AF88}
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2051B7B0-11F4-4ED1-8BEA-4E1A79663A25}"
+	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		scripts\BuildPackageLayout.cmd = scripts\BuildPackageLayout.cmd
+		NuSpec.ReferenceGenerator.nuspec = NuSpec.ReferenceGenerator.nuspec
+		readme.md = readme.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|ARM.Build.0 = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|x64.Build.0 = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Debug|x86.Build.0 = Debug|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|ARM.ActiveCfg = Release|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|ARM.Build.0 = Release|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|x64.ActiveCfg = Release|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|x64.Build.0 = Release|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|x86.ActiveCfg = Release|Any CPU
+		{D3F17CBE-FC99-4B13-92CC-0AD3A1CDEFE7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+if ! [ -x "$(command -v mono)" ]; then
+  echo >&2 "Could not find 'mono' on the path."
+  exit 1
+fi
+
+if ! [ -x "$(command -v curl)" ]; then
+  echo >&2 "Could not find 'curl' on the path."
+  exit 1
+fi
+
+if ! [ -d ../.nuget ]; then
+  mkdir ../.nuget
+fi
+
+if ! [ -x ../.nuget/nuget.exe ]; then
+  echo ""
+  echo "Downloading nuget.exe..."
+  echo ""
+
+  curl https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o ../.nuget/nuget.exe -L
+  if [ $? -ne 0 ]; then
+    echo >&2 ""
+    echo >&2 "The download of nuget.exe has failed."
+    exit 1
+  fi
+
+  chmod 755 ../.nuget/nuget.exe
+fi
+
+echo ""
+echo "Restoring NuGet packages..."
+echo ""
+
+mono ../.nuget/nuget.exe restore ../ReferenceGenerator.Mono.sln
+if [ $? -ne 0 ]; then
+  echo >&2 "NuGet package restore has failed."
+  exit 1
+fi
+
+echo ""
+echo "Building..."
+echo ""
+
+xbuild ../ReferenceGenerator.Mono.sln /property:Configuration=Release
+if [ $? -ne 0 ]; then
+  echo >&2 ""
+  echo >&2 "The build has failed."
+  exit 1
+fi

--- a/scripts/buildpackagelayout.sh
+++ b/scripts/buildpackagelayout.sh
@@ -1,0 +1,19 @@
+if ! [ -d ../artifacts/build/dotnet ]; then
+  mkdir -p ../artifacts/build/dotnet
+fi
+
+if ! [ -d ../artifacts/build/portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10 ]; then
+  mkdir -p ../artifacts/build/portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10
+fi
+
+if ! [ -d ../artifacts/tools ]; then
+  mkdir -p ../artifacts/tools
+fi
+
+chmod 755 ../packages/ILRepack.2.0.8/tools/ILRepack.exe
+
+mono "../packages/ILRepack.2.0.8/tools/ILRepack.exe" "../src/ReferenceGenerator/bin/$1/ReferenceGenerator.exe" "../src/ReferenceGenerator/bin/$1/System.Collections.Immutable.dll" "../src/ReferenceGenerator/bin/$1/System.Reflection.Metadata.dll" "../src/ReferenceGenerator/bin/$1/Newtonsoft.Json.dll" /out:"../artifacts/tools/RefGen.exe" /internalize /targetplatform:"v4,/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks/.NETPortable/v4.5"
+
+cp -f "../src/ReferenceGenerator/bin/$1/ReferenceGenerator.exe.config" "../artifacts/tools/RefGen.exe.config"
+cp -f "../src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets" "../artifacts/build/dotnet/NuSpec.ReferenceGenerator.targets"
+cp -f "../src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets" "../artifacts/build/portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10/NuSpec.ReferenceGenerator.targets"

--- a/src/ReferenceGenerator/ReferenceGenerator.csproj
+++ b/src/ReferenceGenerator/ReferenceGenerator.csproj
@@ -82,7 +82,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)scripts\BuildPackageLayout.cmd" $(Configuration)</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">"$(SolutionDir)scripts\BuildPackageLayout.cmd" $(Configuration)</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">"$(SolutionDir)scripts\buildpackagelayout.sh" $(Configuration)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ReferenceGenerator/packages.config
+++ b/src/ReferenceGenerator/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="2.14.1208" targetFramework="net45" />
+  <package id="ILRepack" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />


### PR DESCRIPTION
This PR is the first attempt at getting the project to build on Mono. To get it building, I have done the following:
- Created a new solution `ReferenceGenerator.Mono.sln` that is the same as the regular solution, but does not include the UWP project, which Mono cannot build as far as I know
- Created a `build.sh` file that can build the solution on Mono. I used [xUnit's build.sh file](https://github.com/xunit/xunit/blob/master/build.sh) as the starting point.
- Created a `buildpackagelayout.sh` file that uses [ILRepack](https://github.com/gluck/il-repack) as ILMerge is not available on Mono
- Modified the `ReferenceGenerator.csproj` file to conditionally execute either the `buildpackagelayout.cmd` file on Windows or `buildpackagelayout.sh` on Mono. This is the most important step in getting it to also build on Mono
- Added the `.nuget` directory to the `.gitignore` file

The `build.sh` succesfully compiles the project on my machine now, but there is still one import step that is not working: the `buildpackagelayout.sh` throws an exception:

```
INFO: IL Repack - Version 2.0.8
INFO: Adding assembly for merge: ../src/ReferenceGenerator/bin/release/ReferenceGenerator.exe
INFO: Adding assembly for merge: ../src/ReferenceGenerator/bin/release/System.Collections.Immutable.dll
INFO: Adding assembly for merge: ../src/ReferenceGenerator/bin/release/System.Reflection.Metadata.dll
INFO: Adding assembly for merge: ../src/ReferenceGenerator/bin/release/Newtonsoft.Json.dll
WARN: Duplicate Win32 resource with id=0, parents=[,
                                                    ], name= in assembly System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, ignoring
INFO: Processing references
INFO: Processing types
INFO: Merging <Module>
INFO: Merging <Module>
INFO: Merging <Module>
INFO: Merging <Module>
INFO: Processing types
INFO: Processing resources
INFO: Fixing references
Mono.Cecil.ResolutionException: Failed to resolve System.Runtime.Serialization.Formatters.FormatterAssemblyStyle
  at Mono.Cecil.Mixin.CheckedResolve (Mono.Cecil.TypeReference self) <0x2a42d70 + 0x00053> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.GetConstantType (Mono.Cecil.TypeReference constant_type, System.Object constant) <0x46121c0 + 0x00053> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.AddConstant (IConstantProvider owner, Mono.Cecil.TypeReference type) <0x4612048 + 0x0002b> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.AddField (Mono.Cecil.FieldDefinition field) <0x4608900 + 0x00163> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.AddFields (Mono.Cecil.TypeDefinition type) <0x4608898 + 0x00043> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.AddType (Mono.Cecil.TypeDefinition type) <0x4607210 + 0x001e7> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.AddTypeDefs () <0x46071a8 + 0x00043> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.BuildTypes () <0x4606718 + 0x0002f> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.BuildModule () <0x4604000 + 0x000e3> in <filename unknown>:0 
  at Mono.Cecil.MetadataBuilder.BuildMetadata () <0x3af3fc0 + 0x00013> in <filename unknown>:0 
  at Mono.Cecil.ModuleWriter.BuildMetadata (Mono.Cecil.ModuleDefinition module, Mono.Cecil.MetadataBuilder metadata) <0x3af3eb0 + 0x0002b> in <filename unknown>:0 
  at Mono.Cecil.ModuleWriter.WriteModuleTo (Mono.Cecil.ModuleDefinition module, System.IO.Stream stream, Mono.Cecil.WriterParameters parameters) <0x3af1660 + 0x00153> in <filename unknown>:0 
  at Mono.Cecil.ModuleDefinition.Write (System.IO.Stream stream, Mono.Cecil.WriterParameters parameters) <0x3af1558 + 0x00063> in <filename unknown>:0 
  at Mono.Cecil.ModuleDefinition.Write (System.String fileName, Mono.Cecil.WriterParameters parameters) <0x3af14d0 + 0x0004b> in <filename unknown>:0 
  at Mono.Cecil.AssemblyDefinition.Write (System.String fileName, Mono.Cecil.WriterParameters parameters) <0x3af1498 + 0x00023> in <filename unknown>:0 
  at ILRepacking.ILRepack.Repack () <0x29e15f0 + 0x00b37> in <filename unknown>:0 
  at ILRepacking.Application.Main (System.String[] args) <0x7e4ed8 + 0x00123> in <filename unknown>:0 
```

I don't really know ILRepack, but to me it appears that it tries to resolve a dependency of Newtonsoft.Json.dll`named`System.Runtime.Serialization.Formatters.FormatterAssemblyStyle`, which it can't find. I did some Googling and found the [following SO link](http://stackoverflow.com/questions/27080363/missingmethodexception-with-newtonsoft-json-when-using-typenameassemblyformat-wi). This appears to be related, but I'm not sure how I can fix this. Any ideas? 
