### PR TITLE
Enable tool to run on mono when it can

### DIFF
--- a/NuSpec.ReferenceGenerator.nuspec
+++ b/NuSpec.ReferenceGenerator.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>NuSpec.ReferenceGenerator</id>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
     <title>NuSpec Dependency Generator</title>
     <authors>Oren Novotny</authors>
     <licenseUrl>https://raw.githubusercontent.com/onovotny/ReferenceGenerator/master/LICENSE.txt</licenseUrl>

--- a/NuSpec.ReferenceGenerator.nuspec
+++ b/NuSpec.ReferenceGenerator.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>NuSpec.ReferenceGenerator</id>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <title>NuSpec Dependency Generator</title>
     <authors>Oren Novotny</authors>
     <licenseUrl>https://raw.githubusercontent.com/onovotny/ReferenceGenerator/master/LICENSE.txt</licenseUrl>

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ This tool is a command line that you can call in other ways. The parameters are 
 - This tool does not currently run on mono if you're using an "classic PCL". The tool needs all of the PCL contracts from the `Reference Assemblies` folder for comparison; if there's an equiv on Mono, then this could be fixed. Alternatively, if you only need project.json based projects, then there's no limitation.
 
 ## Changelog
+- 1.4.1: Issue warning and do not run RefGen on non-Windows systems until full mono compatibility is tested and verified. Prevents breaking builds.
 - 1.4: Fix issue where BCL libs weren't detected correctly for PCL projects using project.json instead of packages.config
 - 1.3.6: Fix TFM version parsing when running on cultures that use `,` instead of `.` ([#14](https://github.com/onovotny/ReferenceGenerator/issues/14))
 - 1.3.5: Fix for pre-release number parsing so that it can work with a "number" group that is larger than `int.MaxValue` ([#13](https://github.com/onovotny/ReferenceGenerator/pull/13))

--- a/src/ReferenceGenerator/Diagnostics.cs
+++ b/src/ReferenceGenerator/Diagnostics.cs
@@ -55,7 +55,7 @@ namespace ReferenceGenerator
             Message = message;
         }
 
-        public static readonly WarningWithMessage ClassicPclUnix = new WarningWithMessage("Classic PCL's, including Profile 259, cannot be updated on non-Windows Operating Systems", "RG002");
+        public static readonly WarningWithMessage ClassicPclUnix = new WarningWithMessage("Classic PCL's, including Profile 259, cannot be updated on non-Windows Operating Systems. No changes have been made.", "RG002");
     }
 
     class Error : Diagnostic

--- a/src/ReferenceGenerator/Diagnostics.cs
+++ b/src/ReferenceGenerator/Diagnostics.cs
@@ -48,6 +48,16 @@ namespace ReferenceGenerator
         public Warning(string code) : base("warning", code) { }
     }
 
+    class WarningWithMessage : Warning
+    {
+        public WarningWithMessage(string message, string code) : base(code)
+        {
+            Message = message;
+        }
+
+        public static readonly WarningWithMessage ClassicPclUnix = new WarningWithMessage("Classic PCL's, including Profile 259, cannot be updated on non-Windows Operating Systems", "RG002");
+    }
+
     class Error : Diagnostic
     {
         public Error(string code) : base("error", code) { }

--- a/src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets
+++ b/src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets
@@ -40,10 +40,12 @@
 
 
     <!-- Build the command here as quotes are easier this way -->
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
       <RefGenExecCmd>"$(MSBuildThisFileDirectory)..\..\tools\RefGen.exe" "$(NuGetTargetMoniker);$(_NuGetTargetFallbackMoniker)" $(NuSpecTfm) "@(NuSpecFile)" "@(NuSpecProjectFile)" "@(NuSpecLibContent)"</RefGenExecCmd>
     </PropertyGroup>
-
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+      <RefGenExecCmd>mono "$(MSBuildThisFileDirectory)../../tools/RefGen.exe" "$(NuGetTargetMoniker);$(_NuGetTargetFallbackMoniker)" $(NuSpecTfm) "@(NuSpecFile)" "@(NuSpecProjectFile)" "@(NuSpecLibContent)"</RefGenExecCmd>
+    </PropertyGroup>
 
     <Exec Command="$(RefGenExecCmd)" />
     <Message Text="Updated Nuspec" />

--- a/src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets
+++ b/src/ReferenceGenerator/NuSpec.ReferenceGenerator.targets
@@ -47,8 +47,9 @@
       <RefGenExecCmd>mono "$(MSBuildThisFileDirectory)../../tools/RefGen.exe" "$(NuGetTargetMoniker);$(_NuGetTargetFallbackMoniker)" $(NuSpecTfm) "@(NuSpecFile)" "@(NuSpecProjectFile)" "@(NuSpecLibContent)"</RefGenExecCmd>
     </PropertyGroup>
 
-    <Exec Command="$(RefGenExecCmd)" />
-    <Message Text="Updated Nuspec" />
+    <Exec Command="$(RefGenExecCmd)" Condition="'$(OS)' == 'Windows_NT'" />
+    <Message Text="Updated Nuspec" Condition="'$(OS)' == 'Windows_NT'" />
+    <Message Text="Warning Nuspec Reference Generator Does not support Linux/Unix yet" Condition="'$(OS)' != 'Windows_NT'" />
 
   </Target>
 </Project>

--- a/tests/SampleClassLibrary/Class1.cs
+++ b/tests/SampleClassLibrary/Class1.cs
@@ -12,7 +12,9 @@ namespace SampleClassLibrary
     [JsonConverter(typeof(StringEnumConverter))]
     public class Class1
     {
+#pragma warning disable 169
         XDocument doc;
+#pragma warning restore 169
         public Class1()
         {
             var md = this.GetType().GetMethod("foo");

--- a/tests/SampleCoreLibrary/Class1.cs
+++ b/tests/SampleCoreLibrary/Class1.cs
@@ -12,7 +12,9 @@ namespace SampleCoreLibrary
     [JsonConverter(null)]
     public class Class1
     {
+#pragma warning disable 169
         XDocument doc;
+#pragma warning restore 169
         public Class1()
         {
             var md = this.GetType().GetRuntimeMethod("foo", null);


### PR DESCRIPTION
This addresses #16 to let the tool run on mono when possible. In the case of "classic PCL's" where it needs the data from the reference assemblies, we issue a warning and return a 0 status code without touching the nuspec file.

A future improvement could detect if the `referenceassemblies-pcl` package is installed (if it contains the required reference assembly data) and ease this restriction.
