### PR TITLE
Netstandard support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,13 +99,12 @@ In some cases, you may need to have multiple dependency groups, like having both
 ## Command line
 This tool is a command line that you can call in other ways. The parameters are as follows and they are all required:
 
-```
-// args 0: NuGetTargetMoniker: .NETPlatform,Version=v5.0
-// args 1: TFM's to generate, semi-colon joined. E.g.: dotnet;uap10.0
-// args 2: nuspec file, full path
-// args 3: project file (csproj/vbproj, etc) full path. Used to look for packages.config/project.json and references. should match order of target files
-// args 4: target files, semi-colon joined, full path
-```
+|Argument Position | Description/Notes|
+|:-------:|-------|
+| 0 |  NuGetTargetMoniker: .NETPlatform,Version=v5.0 |
+| 1 | TFM's to generate, semi-colon joined. E.g.: dotnet;uap10.0 |
+| 2 | nuspec file, full path |
+| 3 | A semi-colon joined list of projectPath=[assemblyPath\|configurationName] pairs. The only required part is projectPath, which shoudl be a fully qualified path to the project. In that case, the tool tries to figure out the assembly path based on the information in the project file. If you provide an assemblyPath, the tool just uses that. If the project is an XPROJ based project, then the configurationName is required. |
 
 ## Limitations
 - This tool does not currently run on mono if you're using an "classic PCL". The tool needs all of the PCL contracts from the `Reference Assemblies` folder for comparison; if there's an equiv on Mono, then this could be fixed. Alternatively, if you only need project.json based projects, then there's no limitation.

--- a/src/ReferenceGenerator.Engine/Project.cs
+++ b/src/ReferenceGenerator.Engine/Project.cs
@@ -1,45 +1,126 @@
-﻿using System;
+﻿using NuGet.Frameworks;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.IO;
 using System.Xml.Linq;
-using NuGet.Frameworks;
 
 namespace ReferenceGenerator.Engine
 {
     public class Project : IEquatable<Project>, IComparable<Project>
     {
-        public Project(string path, string configuration)
+        private string assemblyName;
+        private string assemblyPath;
+        private string configuration;
+        private string platform;
+        private string projectDirectory;
+        private string originalPath;
+
+        public static Project Parse(string pair)
         {
-            ProjectPath = path;
-            ProjectFileName = Path.GetFileNameWithoutExtension(path);
-            ProjectDirectory = Path.GetDirectoryName(path);
-            IsXProject = Path.GetExtension(path).Equals(".xproj", StringComparison.OrdinalIgnoreCase);
-            ConfigurePackageProperties();
-            ConfigurePropertiesFromProjectFile(configuration);
+            var items = pair.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+            // We have to have at least 1 element, which will be the fully qualified
+            // path to the project.
+
+            if (items.Length < 1 || items.Length > 2)
+            {
+                throw new InvalidOperationException("Unable to parse.");
+            }
+
+            var project = new Project(items[0]);
+
+            // It's possible we were only given the path to the project file,
+            // in which case we want to try and automatically figure out
+            // the path to the assembly. This won't work if the project was
+            // an XPROJ because we need to be told which configuration to look
+            // at.
+            if (project.IsXProject && items.Length == 1)
+            {
+                throw new InvalidOperationException("A path to the assembly or a configuration name must be provided.");
+            }
+
+            project.ConfigureAssemblyProperties(items.ElementAtOrDefault(1));
+
+            return project;
         }
 
-        private string AssemblyName { get; set; }
+        private Project(string path)
+        {
+            originalPath = path;
+            projectDirectory = Path.GetDirectoryName(path);
+            ProjectFileName = Path.GetFileNameWithoutExtension(path);
+            IsXProject = Path.GetExtension(path).Equals(".xproj", StringComparison.OrdinalIgnoreCase);
+            ConfigurePackageProperties();
+        }
 
-        private string ProjectPath { get; }
-
-        private string BinaryPath { get; set; }
-
-        public string ProjectFileName { get; }
-
-        private string Platform { get; set; }
-
-        private string Configuration { get; set; }
-
-        private string ProjectDirectory { get; }
-
+        #region properties
         public bool HasProjectJson { get; private set; }
 
-        public bool IsXProject { get; }
+        public bool IsXProject { get; private set; }
 
         public string PackagesFile { get; private set; }
+
+        public string ProjectFileName { get; private set; }
+        #endregion
+
+        #region methods
+
+        private void ConfigureAssemblyProperties(string assemblyPathOrConfiguration)
+        {
+            if (File.Exists(assemblyPathOrConfiguration))
+            {
+                assemblyName = Path.GetFileName(assemblyPathOrConfiguration);
+                assemblyPath = Path.GetDirectoryName(assemblyPathOrConfiguration);
+            }
+            else
+            {
+                var projectDocument = XElement.Load(originalPath);
+                XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+                var currentConfiguration = GetCurrentProjectConfiguration(projectDocument, ns, assemblyPathOrConfiguration);
+                configuration = currentConfiguration.Item1;
+                platform = currentConfiguration.Item2;
+                assemblyName = GetAssemblyName(projectDocument, ns);
+                assemblyPath = GetOutputPathFromProject(projectDocument, ns);
+            }
+        }
+
+        private void ConfigurePackageProperties()
+        {
+            if (File.Exists(Path.Combine(projectDirectory, $"{ProjectFileName}.project.json")))
+            {
+                HasProjectJson = true;
+                PackagesFile = Path.Combine(projectDirectory, $"{ProjectFileName}.project.lock.json");
+            }
+            else if (File.Exists(Path.Combine(projectDirectory, "project.json")))
+            {
+                HasProjectJson = true;
+                PackagesFile = Path.Combine(projectDirectory, "project.lock.json");
+            }
+            else if (File.Exists(Path.Combine(projectDirectory, $"packages.{ProjectFileName}.config")))
+            {
+                HasProjectJson = false;
+                PackagesFile = Path.Combine(projectDirectory, $"packages.{ProjectFileName}.config");
+            }
+            else if (File.Exists(Path.Combine(projectDirectory, "packages.config")))
+            {
+                HasProjectJson = false;
+                PackagesFile = Path.Combine(projectDirectory, "packages.config");
+            }
+            else
+            {
+                // Must be an "old" PCL without any refs. Best we can do is read the refs.
+                HasProjectJson = false;
+                PackagesFile = null;
+            }
+        }
+
+        private string GetAssemblyName(XElement document, XNamespace ns)
+        {
+            return $"{document.Descendants(ns + "AssemblyName").FirstOrDefault()?.Value ?? ProjectFileName}.dll";
+        }
 
         private static Tuple<string, string> GetCurrentProjectConfiguration(XElement document, XNamespace ns, string configuration)
         {
@@ -48,23 +129,13 @@ namespace ReferenceGenerator.Engine
             return Tuple.Create(computedConfiguration, platformNode?.Value ?? String.Empty);
         }
 
-        private static XElement GetPropertyGroup(XElement document, XNamespace ns, string attributeName, string attributeValuePattern)
-        {
-            return document.Descendants(ns + "PropertyGroup").FirstOrDefault(p => p.Attribute(attributeName)?.Value.Contains(attributeValuePattern) ?? false);
-        }
-
-        private string GetAssemblyName(XElement document, XNamespace ns)
-        {
-            return $"{document.Descendants(ns + "AssemblyName").FirstOrDefault()?.Value ?? ProjectFileName}.dll";
-        }
-
         private string GetOutputPathFromProject(XElement document, XNamespace ns)
         {
             var binaryPath = String.Empty;
             var propertyGroup = GetPropertyGroup(document, ns, "Label", "Globals");
             if (propertyGroup == null)
             {
-                var configurationAndPlatform = $"{Configuration}{(String.IsNullOrWhiteSpace(Platform) ? String.Empty : $"|{Platform}")}";
+                var configurationAndPlatform = $"{configuration}{(String.IsNullOrWhiteSpace(platform) ? String.Empty : $"|{platform}")}";
                 propertyGroup = GetPropertyGroup(document, ns, "Condition", configurationAndPlatform);
             }
 
@@ -76,78 +147,21 @@ namespace ReferenceGenerator.Engine
                     outputPath = outputPath.Replace("$(MSBuildProjectName)", ProjectFileName);
                 }
 
-                binaryPath = Path.Combine(ProjectDirectory, outputPath, IsXProject ? Configuration : "");
+                binaryPath = Path.Combine(projectDirectory, outputPath, IsXProject ? configuration : "");
             }
 
             return binaryPath;
         }
 
-        private void ConfigurePropertiesFromProjectFile(string configurationFallback)
+        private static XElement GetPropertyGroup(XElement document, XNamespace ns, string attributeName, string attributeValuePattern)
         {
-            var binaryPath = String.Empty;
-            var projectDocument = XElement.Load(ProjectPath);
-            XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
-
-            var currentConfiguration = GetCurrentProjectConfiguration(projectDocument, ns, configurationFallback);
-            Configuration = currentConfiguration.Item1;
-            Platform = currentConfiguration.Item2;
-            AssemblyName = GetAssemblyName(projectDocument, ns);
-            BinaryPath = GetOutputPathFromProject(projectDocument, ns);
-        }
-
-        private void ConfigurePackageProperties()
-        {
-            if (File.Exists(Path.Combine(ProjectDirectory, $"{ProjectFileName}.project.json")))
-            {
-                HasProjectJson = true;
-                PackagesFile = Path.Combine(ProjectDirectory, $"{ProjectFileName}.project.lock.json");
-            }
-            else if (File.Exists(Path.Combine(ProjectDirectory, "project.json")))
-            {
-                HasProjectJson = true;
-                PackagesFile = Path.Combine(ProjectDirectory, "project.lock.json");
-            }
-            else if (File.Exists(Path.Combine(ProjectDirectory, $"packages.{ProjectFileName}.config")))
-            {
-                HasProjectJson = false;
-                PackagesFile = Path.Combine(ProjectDirectory, $"packages.{ProjectFileName}.config");
-            }
-            else if (File.Exists(Path.Combine(ProjectDirectory, "packages.config")))
-            {
-                HasProjectJson = false;
-                PackagesFile = Path.Combine(ProjectDirectory, "packages.config");
-            }
-            else
-            {
-                // Must be an "old" PCL without any refs. Best we can do is read the refs.
-                HasProjectJson = false;
-                PackagesFile = null;
-            }
-        }
-
-        public AssemblyInfo GetAssemblyInfo()
-        {
-            return AssemblyInfo.GetAssemblyInfo(Path.Combine(BinaryPath, AssemblyName));
-        }
-
-        public AssemblyInfo GetAssemblyInfo(NuGetFramework tfm)
-        {
-            return AssemblyInfo.GetAssemblyInfo(Path.Combine(BinaryPath, tfm.GetShortFolderName(), AssemblyName));
+            return document.Descendants(ns + "PropertyGroup").FirstOrDefault(p => p.Attribute(attributeName)?.Value.Contains(attributeValuePattern) ?? false);
         }
 
         public int CompareTo(Project other)
         {
             // sort on name for now
-            return StringComparer.OrdinalIgnoreCase.Compare(ProjectPath, other?.ProjectPath);
-        }
-
-        public bool Equals(Project other)
-        {
-            if (ReferenceEquals(other, null))
-                return false;
-
-            return string.Equals(ProjectPath, other.ProjectPath, StringComparison.OrdinalIgnoreCase) &&
-                   Equals(BinaryPath, other.BinaryPath);
+            return StringComparer.OrdinalIgnoreCase.Compare(originalPath, other?.originalPath);
         }
 
         public override bool Equals(object obj)
@@ -155,9 +169,29 @@ namespace ReferenceGenerator.Engine
             return Equals(obj as Package);
         }
 
+        public bool Equals(Project other)
+        {
+            if (ReferenceEquals(other, null))
+                return false;
+
+            return string.Equals(originalPath, other.originalPath, StringComparison.OrdinalIgnoreCase) &&
+                   Equals(assemblyPath, other.assemblyPath);
+        }
+
+        public AssemblyInfo GetAssemblyInfo()
+        {
+            return AssemblyInfo.GetAssemblyInfo(Path.Combine(assemblyPath, assemblyName));
+        }
+
+        public AssemblyInfo GetAssemblyInfo(NuGetFramework tfm)
+        {
+            return AssemblyInfo.GetAssemblyInfo(Path.Combine(assemblyPath, tfm.GetShortFolderName(), assemblyName));
+        }
+
         public override int GetHashCode()
         {
-            return unchecked(ProjectPath?.GetHashCode() ?? 1 ^ BinaryPath?.GetHashCode() ?? 1);
+            return unchecked(originalPath?.GetHashCode() ?? 1 ^ assemblyPath?.GetHashCode() ?? 1);
         }
+        #endregion
     }
 }

--- a/src/ReferenceGenerator.Engine/Project.cs
+++ b/src/ReferenceGenerator.Engine/Project.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace ReferenceGenerator.Engine
+{
+    public class Project : IEquatable<Project>, IComparable<Project>
+    {
+        public Project(string path, string binaryPath)
+        {
+            ProjectPath = path;
+            BinaryPath = binaryPath;
+            ProjectFileName = Path.GetFileNameWithoutExtension(path);
+            ProjectDirectory = Path.GetDirectoryName(path);
+
+            if (File.Exists(Path.Combine(ProjectDirectory, $"{ProjectFileName}.project.json")))
+            {
+                HasProjectJson = true;
+                PackagesFile = Path.Combine(ProjectDirectory, $"{ProjectFileName}.project.lock.json");
+            }
+            else if (File.Exists(Path.Combine(ProjectDirectory, "project.json")))
+            {
+                HasProjectJson = true;
+                PackagesFile = Path.Combine(ProjectDirectory, "project.lock.json");
+            }
+            else if (File.Exists(Path.Combine(ProjectDirectory, $"packages.{ProjectFileName}.config")))
+            {
+                HasProjectJson = false;
+                PackagesFile = Path.Combine(ProjectDirectory, $"packages.{ProjectFileName}.config");
+            }
+            else if (File.Exists(Path.Combine(ProjectDirectory, "packages.config")))
+            {
+                HasProjectJson = false;
+                PackagesFile = Path.Combine(ProjectDirectory, "packages.config");
+            }
+            else
+            {
+                // Must be an "old" PCL without any refs. Best we can do is read the refs.
+                HasProjectJson = false;
+                PackagesFile = null;
+            }
+        }
+
+        public string ProjectPath { get; }
+
+        public string BinaryPath { get; }
+
+        public string ProjectFileName { get; }
+
+        public string ProjectDirectory { get; }
+        public bool HasProjectJson { get; }
+
+        public string PackagesFile { get; }
+
+        public AssemblyInfo GetAssemblyInfo()
+        {
+            return AssemblyInfo.GetAssemblyInfo(BinaryPath);
+        }
+
+        public int CompareTo(Project other)
+        {
+            // sort on name for now
+            return StringComparer.OrdinalIgnoreCase.Compare(ProjectPath, other?.ProjectPath);
+        }
+
+        public bool Equals(Project other)
+        {
+            if (ReferenceEquals(other, null))
+                return false;
+
+            return string.Equals(ProjectPath, other.ProjectPath, StringComparison.OrdinalIgnoreCase) &&
+                   Equals(BinaryPath, other.BinaryPath);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Package);
+        }
+
+        public override int GetHashCode()
+        {
+            return unchecked(ProjectPath?.GetHashCode() ?? 1 ^ BinaryPath?.GetHashCode() ?? 1);
+        }
+    }
+}

--- a/src/ReferenceGenerator.Engine/Project.cs
+++ b/src/ReferenceGenerator.Engine/Project.cs
@@ -4,18 +4,99 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.IO;
+using System.Xml.Linq;
+using NuGet.Frameworks;
 
 namespace ReferenceGenerator.Engine
 {
     public class Project : IEquatable<Project>, IComparable<Project>
     {
-        public Project(string path, string binaryPath)
+        public Project(string path, string configuration)
         {
             ProjectPath = path;
-            BinaryPath = binaryPath;
             ProjectFileName = Path.GetFileNameWithoutExtension(path);
             ProjectDirectory = Path.GetDirectoryName(path);
+            IsXProject = Path.GetExtension(path).Equals(".xproj", StringComparison.OrdinalIgnoreCase);
+            ConfigurePackageProperties();
+            ConfigurePropertiesFromProjectFile(configuration);
+        }
 
+        private string AssemblyName { get; set; }
+
+        private string ProjectPath { get; }
+
+        private string BinaryPath { get; set; }
+
+        public string ProjectFileName { get; }
+
+        private string Platform { get; set; }
+
+        private string Configuration { get; set; }
+
+        private string ProjectDirectory { get; }
+
+        public bool HasProjectJson { get; private set; }
+
+        public bool IsXProject { get; }
+
+        public string PackagesFile { get; private set; }
+
+        private static Tuple<string, string> GetCurrentProjectConfiguration(XElement document, XNamespace ns, string configuration)
+        {
+            var computedConfiguration = document.Descendants(ns + "Configuration").SingleOrDefault()?.Value ?? configuration;
+            var platformNode = document.Descendants(ns + "Platform").SingleOrDefault();
+            return Tuple.Create(computedConfiguration, platformNode?.Value ?? String.Empty);
+        }
+
+        private static XElement GetPropertyGroup(XElement document, XNamespace ns, string attributeName, string attributeValuePattern)
+        {
+            return document.Descendants(ns + "PropertyGroup").FirstOrDefault(p => p.Attribute(attributeName)?.Value.Contains(attributeValuePattern) ?? false);
+        }
+
+        private string GetAssemblyName(XElement document, XNamespace ns)
+        {
+            return $"{document.Descendants(ns + "AssemblyName").FirstOrDefault()?.Value ?? ProjectFileName}.dll";
+        }
+
+        private string GetOutputPathFromProject(XElement document, XNamespace ns)
+        {
+            var binaryPath = String.Empty;
+            var propertyGroup = GetPropertyGroup(document, ns, "Label", "Globals");
+            if (propertyGroup == null)
+            {
+                var configurationAndPlatform = $"{Configuration}{(String.IsNullOrWhiteSpace(Platform) ? String.Empty : $"|{Platform}")}";
+                propertyGroup = GetPropertyGroup(document, ns, "Condition", configurationAndPlatform);
+            }
+
+            if (propertyGroup != null)
+            {
+                var outputPath = propertyGroup.Element(ns + "OutputPath").Value;
+                if (outputPath.Contains("$(MSBuildProjectName)"))
+                {
+                    outputPath = outputPath.Replace("$(MSBuildProjectName)", ProjectFileName);
+                }
+
+                binaryPath = Path.Combine(ProjectDirectory, outputPath, IsXProject ? Configuration : "");
+            }
+
+            return binaryPath;
+        }
+
+        private void ConfigurePropertiesFromProjectFile(string configurationFallback)
+        {
+            var binaryPath = String.Empty;
+            var projectDocument = XElement.Load(ProjectPath);
+            XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+            var currentConfiguration = GetCurrentProjectConfiguration(projectDocument, ns, configurationFallback);
+            Configuration = currentConfiguration.Item1;
+            Platform = currentConfiguration.Item2;
+            AssemblyName = GetAssemblyName(projectDocument, ns);
+            BinaryPath = GetOutputPathFromProject(projectDocument, ns);
+        }
+
+        private void ConfigurePackageProperties()
+        {
             if (File.Exists(Path.Combine(ProjectDirectory, $"{ProjectFileName}.project.json")))
             {
                 HasProjectJson = true;
@@ -44,20 +125,14 @@ namespace ReferenceGenerator.Engine
             }
         }
 
-        public string ProjectPath { get; }
-
-        public string BinaryPath { get; }
-
-        public string ProjectFileName { get; }
-
-        public string ProjectDirectory { get; }
-        public bool HasProjectJson { get; }
-
-        public string PackagesFile { get; }
-
         public AssemblyInfo GetAssemblyInfo()
         {
-            return AssemblyInfo.GetAssemblyInfo(BinaryPath);
+            return AssemblyInfo.GetAssemblyInfo(Path.Combine(BinaryPath, AssemblyName));
+        }
+
+        public AssemblyInfo GetAssemblyInfo(NuGetFramework tfm)
+        {
+            return AssemblyInfo.GetAssemblyInfo(Path.Combine(BinaryPath, tfm.GetShortFolderName(), AssemblyName));
         }
 
         public int CompareTo(Project other)

--- a/src/ReferenceGenerator.Engine/ProjectEngine.cs
+++ b/src/ReferenceGenerator.Engine/ProjectEngine.cs
@@ -235,14 +235,14 @@ namespace ReferenceGenerator.Engine
         public static IEnumerable<PackageWithReference> GetProjectPackages(Project project, NuGetFramework[] nugetTargetMonikers)
         {
             var packages = new List<PackageWithReference>();
-            var assm = project.GetAssemblyInfo();
             if (project.HasProjectJson)
             {
-                packages.AddRange(ProjectEngine.GetProjectJsonPackages(project.PackagesFile, assm.References, nugetTargetMonikers));
+                AssemblyInfo assemblyInfo = project.IsXProject ? project.GetAssemblyInfo(nugetTargetMonikers[0]) : project.GetAssemblyInfo();
+                packages.AddRange(ProjectEngine.GetProjectJsonPackages(project.PackagesFile, assemblyInfo.References, nugetTargetMonikers));
             }
             else
             {
-                packages.AddRange(ProjectEngine.GetPackagesConfigPackages(project.PackagesFile, project.PackagesFile, assm.References));
+                packages.AddRange(ProjectEngine.GetPackagesConfigPackages(project.PackagesFile, project.PackagesFile, project.GetAssemblyInfo().References));
             }
 
             return packages;

--- a/src/ReferenceGenerator.Engine/ReferenceGenerator.Engine.csproj
+++ b/src/ReferenceGenerator.Engine/ReferenceGenerator.Engine.csproj
@@ -48,6 +48,7 @@
     <Compile Include="FrameworkListCollection.cs" />
     <Compile Include="Package.cs" />
     <Compile Include="PackageWithReferences.cs" />
+    <Compile Include="Project.cs" />
     <Compile Include="ProjectEngine.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/src/ReferenceGenerator/Program.cs
+++ b/src/ReferenceGenerator/Program.cs
@@ -52,15 +52,7 @@ namespace ReferenceGenerator
             {
                 foreach(var pair in pairs)
                 {
-                    var pieces = pair.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (pieces.Length == 2)
-                    {
-                        projects.Add(new Project(pieces[0], pieces[1]));
-                    }
-                    else if (pieces.Length == 1)
-                    {
-                        projects.Add(new Project(pieces[0], String.Empty));
-                    }
+                    projects.Add(Project.Parse(pair));
                 }
             }
 
@@ -72,7 +64,7 @@ namespace ReferenceGenerator
             // args 0: NuGetTargetMonikers -- .NETStandard,Version=v1.4
             // args 1: TFM's to generate, semi-colon joined. E.g.: auto;uap10.0
             // args 2: nuspec file
-            // args 3: a semi-colon joined list of project file/configuration pairs. The configuration is only needed for xproj based projects.
+            // args 3: a semi-colon joined list of projectPath=[assemblyPath|configuration] pairs. The configuration is only needed for xproj based projects and the whole piece is optional.
 
             try
             {

--- a/src/ReferenceGenerator/Program.cs
+++ b/src/ReferenceGenerator/Program.cs
@@ -57,6 +57,10 @@ namespace ReferenceGenerator
                     {
                         projects.Add(new Project(pieces[0], pieces[1]));
                     }
+                    else if (pieces.Length == 1)
+                    {
+                        projects.Add(new Project(pieces[0], String.Empty));
+                    }
                 }
             }
 
@@ -68,7 +72,7 @@ namespace ReferenceGenerator
             // args 0: NuGetTargetMonikers -- .NETStandard,Version=v1.4
             // args 1: TFM's to generate, semi-colon joined. E.g.: auto;uap10.0
             // args 2: nuspec file
-            // args 3: a semi-colon joined list of project/target file pairs.
+            // args 3: a semi-colon joined list of project file/configuration pairs. The configuration is only needed for xproj based projects.
 
             try
             {


### PR DESCRIPTION
The logic and complexity around figuring out the project information has been moved in to a new Project class. This keeps it all self-contained and lets the engine work with csproj/vbproj/xproj files and lets it use the information in the project files to figure out the path to the binary. I also added a new method to `ProjectEngine` called `GetProjectPackages` which takes a `Project` instance instead of a path to the project.lock/packages.config file so the engine has the responsibility of figuring out which method to call (`GetProjectJsonPackages` or `GetPackagesConfigPackages`).

All of this also let me simplify the command line args by dropping the fourth argument. Arg 3 is still a semi-colon delimited list, but it can be a list of just project files `"tests\SampleProjJsonPcl\SampleProjJsonPcl.csproj;"` or project file and configuration '`"tests\SampleProjJsonPcl\SampleProjJsonPcl.csproj=Debug;"`
